### PR TITLE
Add end-to-end and unit tests for Dashboard and related components

### DIFF
--- a/frontend/e2e/bacteria-detail.spec.ts
+++ b/frontend/e2e/bacteria-detail.spec.ts
@@ -1,0 +1,180 @@
+import { test, expect } from '@playwright/test'
+import { ORGANISM_DB } from '../src/data/organisms'
+
+/**
+ * E2E tests for the Bacteria Detail page.
+ *
+ * All data is drawn from the static ORGANISM_DB, so tests run without
+ * a backend.  We primarily test with Escherichia coli (the default /
+ * most data-rich entry) and verify a second organism to confirm routing.
+ */
+test.describe('Bacteria Detail page — Escherichia coli', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/bacteria/Escherichia%20coli')
+  })
+
+  /* ── Header / identity ────────────────────────────────────────── */
+
+  test('renders the organism name in the heading', async ({ page }) => {
+    const name = page.locator('.organism-name')
+    await expect(name).toContainText('Escherichia coli')
+  })
+
+  test('renders the gram stain meta pill', async ({ page }) => {
+    const gram = page.locator('.gram-pill')
+    await expect(gram).toHaveText('Gram-negative')
+  })
+
+  test('renders the common name meta pill', async ({ page }) => {
+    const pills = page.locator('.meta-pill')
+    const texts = await pills.allTextContents()
+    expect(texts.some((t) => t.includes('E. coli'))).toBe(true)
+  })
+
+  test('renders the organism description paragraph', async ({ page }) => {
+    const desc = page.locator('.organism-desc')
+    await expect(desc).toBeVisible()
+    await expect(desc).not.toBeEmpty()
+  })
+
+  /* ── Back button ─────────────────────────────────────────────── */
+
+  test('renders a back-to-Dashboard button', async ({ page }) => {
+    const btn = page.locator('.back-btn')
+    await expect(btn).toBeVisible()
+    await expect(btn).toContainText('Dashboard')
+  })
+
+  test('back button navigates to the dashboard', async ({ page }) => {
+    await page.locator('.back-btn').click()
+    await expect(page).toHaveURL('/')
+    await expect(page.locator('.page-title')).toHaveText('Dashboard')
+  })
+
+  /* ── KPI cards ────────────────────────────────────────────────── */
+
+  test('renders 4 KPI cards', async ({ page }) => {
+    const cards = page.locator('.kpi-card')
+    await expect(cards).toHaveCount(4)
+  })
+
+  test('total detections KPI shows a number', async ({ page }) => {
+    const firstValue = page.locator('.kpi-value').first()
+    await expect(firstValue).not.toBeEmpty()
+    // E. coli has 1,547 detections
+    await expect(firstValue).toContainText('1,547')
+  })
+
+  test('MDRO rate KPI shows a percentage', async ({ page }) => {
+    // Third KPI card (.kpi-value--red) is resistance rate
+    const rateValue = page.locator('.kpi-value--red')
+    await expect(rateValue).toContainText('%')
+  })
+
+  test('resistance profile KPI shows R / I / S pills', async ({ page }) => {
+    await expect(page.locator('.ris-r')).toBeVisible()
+    await expect(page.locator('.ris-i')).toBeVisible()
+    await expect(page.locator('.ris-s')).toBeVisible()
+  })
+
+  test('R pill label starts with "R"', async ({ page }) => {
+    const rPill = page.locator('.ris-r')
+    const text = await rPill.textContent()
+    expect(text?.trim().startsWith('R')).toBe(true)
+  })
+
+  /* ── Panel sections ───────────────────────────────────────────── */
+
+  test('renders Detection Trend chart panel', async ({ page }) => {
+    const title = page.locator('.panel-title', { hasText: 'Detection Trend' })
+    await expect(title).toBeVisible()
+  })
+
+  test('renders Resistance by Antibiotic Class chart panel', async ({ page }) => {
+    const title = page.locator('.panel-title', { hasText: 'Resistance by Antibiotic Class' })
+    await expect(title).toBeVisible()
+  })
+
+  test('renders Antibiotic Resistance Profile section', async ({ page }) => {
+    const title = page.locator('.panel-title', { hasText: 'Antibiotic Resistance Profile' })
+    await expect(title).toBeVisible()
+  })
+
+  test('renders AMR Resistance Genes table panel', async ({ page }) => {
+    const title = page.locator('.panel-title', { hasText: 'AMR Resistance Genes' })
+    await expect(title).toBeVisible()
+  })
+
+  test('AMR genes subtitle shows correct gene count', async ({ page }) => {
+    const ecoli = ORGANISM_DB['Escherichia coli']
+    const subtitle = page.locator('.panel-subtitle', { hasText: 'genes detected' })
+    await expect(subtitle).toContainText(`${ecoli.genes.length} genes detected`)
+  })
+
+  test('renders AMR gene symbol code elements', async ({ page }) => {
+    const geneNames = page.locator('.gene-name')
+    await expect(geneNames.first()).toBeVisible()
+    await expect(geneNames.first()).toContainText('bla') // E. coli top gene starts with bla
+  })
+
+  test('renders Affected River Sites panel', async ({ page }) => {
+    const title = page.locator('.panel-title', { hasText: 'Affected River Sites' })
+    await expect(title).toBeVisible()
+  })
+
+  test('river site rows show site IDs', async ({ page }) => {
+    const siteIds = page.locator('.site-id')
+    await expect(siteIds.first()).toBeVisible()
+  })
+
+  test('renders WGS / Genomic Metrics panel', async ({ page }) => {
+    const title = page.locator('.panel-title', { hasText: 'WGS / Genomic Metrics' })
+    await expect(title).toBeVisible()
+  })
+})
+
+/* ── Second organism — routing sanity ──────────────────────────── */
+test.describe('Bacteria Detail page — Klebsiella pneumoniae', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/bacteria/Klebsiella%20pneumoniae')
+  })
+
+  test('renders organism name for Klebsiella pneumoniae', async ({ page }) => {
+    const name = page.locator('.organism-name')
+    await expect(name).toContainText('Klebsiella pneumoniae')
+  })
+
+  test('renders different detection count than E. coli', async ({ page }) => {
+    const klebsiella = ORGANISM_DB['Klebsiella pneumoniae']
+    const firstValue = page.locator('.kpi-value').first()
+    await expect(firstValue).toContainText(klebsiella.detectionCount.toLocaleString())
+  })
+})
+
+/* ── Fallback for unknown organism ─────────────────────────────── */
+test.describe('Bacteria Detail page — unknown organism fallback', () => {
+  test('falls back to Escherichia coli for an unrecognised organism name', async ({ page }) => {
+    await page.goto('/bacteria/Unknown%20Organism%20XYZ')
+    const name = page.locator('.organism-name')
+    await expect(name).toContainText('Escherichia coli')
+  })
+})
+
+/* ── Dashboard → Bacteria Detail navigation flow ───────────────── */
+test.describe('Cross-page navigation', () => {
+  test('navigating from dashboard organism row reaches bacteria detail', async ({ page }) => {
+    await page.goto('/')
+
+    // Click on the first organism name in the organisms table
+    const firstOrg = page.locator('.org-name').first()
+    await expect(firstOrg).toBeVisible()
+    const orgName = await firstOrg.textContent()
+
+    const row = page.locator('tr', { has: firstOrg })
+    await row.click()
+
+    await expect(page).toHaveURL(/\/bacteria\//)
+    // After navigation, the organism heading should match what was clicked
+    await expect(page.locator('.organism-name')).toContainText(orgName?.trim() ?? '')
+  })
+})

--- a/frontend/e2e/dashboard.spec.ts
+++ b/frontend/e2e/dashboard.spec.ts
@@ -1,0 +1,142 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * E2E tests for the Dashboard page.
+ *
+ * The app always falls back to static mockdata when the backend is
+ * unavailable, so these tests are stable regardless of whether Spring
+ * Boot is running.
+ */
+test.describe('Dashboard page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/')
+  })
+
+  /* ── Page structure ────────────────────────────────────────────── */
+
+  test('renders the Dashboard page title', async ({ page }) => {
+    await expect(page.locator('.page-title')).toHaveText('Dashboard')
+  })
+
+  test('renders 4 stat cards', async ({ page }) => {
+    const cards = page.locator('.stat-card')
+    await expect(cards).toHaveCount(4)
+  })
+
+  test('stat cards display labels', async ({ page }) => {
+    const labels = page.locator('.stat-label')
+    await expect(labels.nth(0)).toContainText('MDRO Incident Rate')
+    await expect(labels.nth(1)).toContainText('Total Samples')
+  })
+
+  test('stat cards display numeric values', async ({ page }) => {
+    // Values either come from live API or from static mockdata; either way
+    // the first card value should be non-empty.
+    const firstValue = page.locator('.stat-value').first()
+    await expect(firstValue).not.toBeEmpty()
+  })
+
+  /* ── AMR Detections chart panel ────────────────────────────────── */
+
+  test('renders AMR Detections by Month chart panel', async ({ page }) => {
+    const title = page.locator('.panel-title', { hasText: 'AMR Detections by Month' })
+    await expect(title).toBeVisible()
+  })
+
+  test('renders year toggle buttons', async ({ page }) => {
+    const yearBtns = page.locator('.year-btn')
+    await expect(yearBtns.first()).toBeVisible()
+  })
+
+  test('has at least one year button marked active', async ({ page }) => {
+    const activeBtn = page.locator('.year-btn--active')
+    await expect(activeBtn).toBeVisible()
+  })
+
+  /* ── Province Risk panel ────────────────────────────────────────── */
+
+  test('renders Risk by Province panel', async ({ page }) => {
+    const title = page.locator('.panel-title', { hasText: 'Risk by Province' })
+    await expect(title).toBeVisible()
+  })
+
+  test('renders province rows with Gauteng', async ({ page }) => {
+    const gauteng = page.locator('.province-name', { hasText: 'Gauteng' })
+    await expect(gauteng).toBeVisible()
+  })
+
+  test('province rows show risk badges (HIGH / MED / LOW)', async ({ page }) => {
+    const badges = page.locator('.province-badge')
+    await expect(badges.first()).toBeVisible()
+    const firstText = await badges.first().textContent()
+    expect(['HIGH', 'MED', 'LOW']).toContain(firstText?.trim())
+  })
+
+  /* ── Top Detected Organisms table ──────────────────────────────── */
+
+  test('renders Top Detected Organisms section heading', async ({ page }) => {
+    const title = page.locator('.panel-title', { hasText: 'Top Detected Organisms' })
+    await expect(title).toBeVisible()
+  })
+
+  test('organisms table contains at least one row', async ({ page }) => {
+    // DataTable renders p-datatable rows; or the stub might render italics
+    const organisms = page.locator('.org-name')
+    await expect(organisms.first()).toBeVisible()
+  })
+
+  test('organism row names are displayed in italic', async ({ page }) => {
+    const firstName = page.locator('.org-name').first()
+    await expect(firstName).toBeVisible()
+  })
+
+  /* ── Top Resistance Genes table ─────────────────────────────────── */
+
+  test('renders Top Resistance Genes section heading', async ({ page }) => {
+    const title = page.locator('.panel-title', { hasText: 'Top Resistance Genes' })
+    await expect(title).toBeVisible()
+  })
+
+  test('resistance gene symbols are displayed in code elements', async ({ page }) => {
+    const genes = page.locator('.gene-name')
+    await expect(genes.first()).toBeVisible()
+  })
+
+  /* ── Affected River Sites table ─────────────────────────────────── */
+
+  test('renders Affected River Sites section heading', async ({ page }) => {
+    const title = page.locator('.panel-title', { hasText: 'Affected River Sites' })
+    await expect(title).toBeVisible()
+  })
+
+  test('river site IDs are shown (code-style spans)', async ({ page }) => {
+    const siteIds = page.locator('.site-id')
+    await expect(siteIds.first()).toBeVisible()
+  })
+
+  /* ── Sidebar / layout ────────────────────────────────────────────── */
+
+  test('page does not show a visible error banner by default', async ({ page }) => {
+    // The error banner would only appear if all API calls fail AND
+    // the component rendered it — currently DashboardView silently
+    // falls back to mockdata, so there should be no error text visible.
+    const errorElements = page.locator('[class*="error"]')
+    await expect(errorElements).toHaveCount(0)
+  })
+
+  /* ── Navigation to Bacteria Detail ──────────────────────────────── */
+
+  test('clicking an organism row navigates to bacteria detail', async ({ page }) => {
+    // Wait for the organisms table to render
+    const firstOrg = page.locator('.org-name').first()
+    await expect(firstOrg).toBeVisible()
+
+    // The DataTable row has a click handler (goToBacteria)
+    // Click on the row containing the first organism name
+    const row = page.locator('tr', { has: firstOrg })
+    await row.click()
+
+    // Should navigate to /bacteria/...
+    await expect(page).toHaveURL(/\/bacteria\//)
+  })
+})

--- a/frontend/src/components/__tests__/StatCard.spec.ts
+++ b/frontend/src/components/__tests__/StatCard.spec.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import StatCard from '@/components/amr/StatCard.vue'
+
+describe('StatCard', () => {
+  const baseProps = {
+    label: 'MDRO Incident Rate',
+    value: '63.3%',
+    trendText: '+3.2% from 2024',
+  }
+
+  it('renders the label', () => {
+    const wrapper = mount(StatCard, { props: baseProps })
+    expect(wrapper.find('.stat-label').text()).toBe('MDRO Incident Rate')
+  })
+
+  it('renders the value', () => {
+    const wrapper = mount(StatCard, { props: baseProps })
+    expect(wrapper.find('.stat-value').text()).toBe('63.3%')
+  })
+
+  it('renders the trend text', () => {
+    const wrapper = mount(StatCard, { props: baseProps })
+    expect(wrapper.find('.stat-trend').text()).toContain('+3.2% from 2024')
+  })
+
+  it('is not visible by default (missing stat-card--visible class)', () => {
+    const wrapper = mount(StatCard, { props: baseProps })
+    expect(wrapper.classes()).not.toContain('stat-card--visible')
+  })
+
+  it('gains stat-card--visible class when visible prop is true', () => {
+    const wrapper = mount(StatCard, { props: { ...baseProps, visible: true } })
+    expect(wrapper.classes()).toContain('stat-card--visible')
+  })
+
+  it('applies transition delay style when delay prop is provided', () => {
+    const wrapper = mount(StatCard, { props: { ...baseProps, delay: 150 } })
+    expect(wrapper.attributes('style')).toContain('150ms')
+  })
+
+  it('renders the trend icon when trendIcon prop is provided', () => {
+    const wrapper = mount(StatCard, {
+      props: { ...baseProps, trendIcon: 'pi-sort-up-fill' },
+    })
+    const icon = wrapper.find('i.pi')
+    expect(icon.exists()).toBe(true)
+    expect(icon.classes()).toContain('pi-sort-up-fill')
+  })
+
+  it('does not render a trend icon when trendIcon is null', () => {
+    const wrapper = mount(StatCard, { props: { ...baseProps, trendIcon: null } })
+    expect(wrapper.find('i.pi').exists()).toBe(false)
+  })
+
+  it('applies trendClass to the trend container', () => {
+    const wrapper = mount(StatCard, {
+      props: { ...baseProps, trendClass: 'trend-danger' },
+    })
+    expect(wrapper.find('.stat-trend').classes()).toContain('trend-danger')
+  })
+
+  it('defaults to trend-muted trendClass', () => {
+    const wrapper = mount(StatCard, { props: baseProps })
+    expect(wrapper.find('.stat-trend').classes()).toContain('trend-muted')
+  })
+
+  it('applies valueClass to the value element', () => {
+    const wrapper = mount(StatCard, {
+      props: { ...baseProps, valueClass: 'value-blue' },
+    })
+    expect(wrapper.find('.stat-value').classes()).toContain('value-blue')
+  })
+})

--- a/frontend/src/stores/__tests__/dashboard.spec.ts
+++ b/frontend/src/stores/__tests__/dashboard.spec.ts
@@ -1,0 +1,287 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useDashboardStore } from '@/stores/dashboard'
+
+/* ── Mock the API layer so no real HTTP requests are made ──────── */
+vi.mock('@/api/dashboard', () => ({
+  dashboardApi: {
+    incidentRate:        vi.fn(),
+    sampleCount:         vi.fn(),
+    highRiskSites:       vi.fn(),
+    monthlyCases:        vi.fn(),
+    monthlyTrendBestYear:vi.fn(),
+    riskByProvince:      vi.fn(),
+    topOrganisms:        vi.fn(),
+    topResistanceGenes:  vi.fn(),
+    affectedRiverSites:  vi.fn(),
+    availableYears:      vi.fn(),
+    monthlyTrend:        vi.fn(),
+  },
+}))
+
+import { dashboardApi } from '@/api/dashboard'
+
+// Typed helpers for mocking
+const api = dashboardApi as Record<string, ReturnType<typeof vi.fn>>
+
+describe('useDashboardStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+    // Default: all API calls reject (simulates backend unavailable)
+    Object.values(api).forEach((fn) => fn.mockRejectedValue(new Error('Network error')))
+  })
+
+  /* ── Initial state ───────────────────────────────────────────── */
+
+  it('starts with loading false', () => {
+    const store = useDashboardStore()
+    expect(store.loading).toBe(false)
+  })
+
+  it('starts with trendLoading false', () => {
+    const store = useDashboardStore()
+    expect(store.trendLoading).toBe(false)
+  })
+
+  it('starts with no error', () => {
+    const store = useDashboardStore()
+    expect(store.error).toBeNull()
+  })
+
+  it('starts with empty availableYears', () => {
+    const store = useDashboardStore()
+    expect(store.availableYears).toEqual([])
+  })
+
+  it('starts with hasIsolateData false', () => {
+    const store = useDashboardStore()
+    expect(store.hasIsolateData).toBe(false)
+  })
+
+  it('statCards returns null before any fetch', () => {
+    const store = useDashboardStore()
+    expect(store.statCards).toBeNull()
+  })
+
+  it('provinces returns null before any fetch', () => {
+    const store = useDashboardStore()
+    expect(store.provinces).toBeNull()
+  })
+
+  /* ── fetchAll with all failures ──────────────────────────────── */
+
+  it('sets error message when all API calls fail', async () => {
+    const store = useDashboardStore()
+    await store.fetchAll()
+    expect(store.error).toBe('Dashboard data unavailable — showing cached data.')
+  })
+
+  it('sets loading back to false after fetchAll (all failures)', async () => {
+    const store = useDashboardStore()
+    await store.fetchAll()
+    expect(store.loading).toBe(false)
+  })
+
+  /* ── fetchAll with topOrganisms success → hasIsolateData ─────── */
+
+  it('sets hasIsolateData true when topOrganisms returns organisms', async () => {
+    api.topOrganisms.mockResolvedValue({
+      organisms: [
+        { name: 'Escherichia coli', arCode: 'ESBL', detectionCount: 1547, siteCount: 14, yoyTrend: 'up', resistanceRate: 38.7 },
+      ],
+    })
+
+    const store = useDashboardStore()
+    await store.fetchAll()
+    expect(store.hasIsolateData).toBe(true)
+  })
+
+  it('maps topOrganisms API response into topOrganisms computed', async () => {
+    api.topOrganisms.mockResolvedValue({
+      organisms: [
+        { name: 'Klebsiella pneumoniae', arCode: 'CRE', detectionCount: 800, siteCount: 9, yoyTrend: 'down', resistanceRate: 52.0 },
+      ],
+    })
+
+    const store = useDashboardStore()
+    await store.fetchAll()
+
+    expect(store.topOrganisms).toHaveLength(1)
+    expect(store.topOrganisms![0]).toMatchObject({
+      name: 'Klebsiella pneumoniae',
+      arCode: 'CRE',
+      detectionCount: 800,
+      siteCount: 9,
+      yoyTrend: 'down',
+      resistanceRate: 52.0,
+    })
+  })
+
+  /* ── statCards computed mapping ──────────────────────────────── */
+
+  it('maps incidentRate response into statCards[0]', async () => {
+    api.incidentRate.mockResolvedValue({ rate: 55.5, comparedToYear: 2024, delta: 2.1, direction: 'up' })
+
+    const store = useDashboardStore()
+    await store.fetchAll()
+
+    const card = store.statCards?.find((c) => c.id === 'incident-rate')
+    expect(card?.value).toBe('55.5%')
+    expect(card?.trendClass).toBe('trend-danger')
+  })
+
+  it('maps sampleCount response into statCards[1]', async () => {
+    api.sampleCount.mockResolvedValue({ total: 200, siteCount: 20 })
+
+    const store = useDashboardStore()
+    await store.fetchAll()
+
+    const card = store.statCards?.find((c) => c.id === 'sample-count')
+    expect(card?.value).toBe('200')
+    expect(card?.trendText).toBe('Across 20 sites')
+  })
+
+  it('maps highRiskSites response into statCards[2]', async () => {
+    api.highRiskSites.mockResolvedValue({ count: 8, newThisMonth: 3 })
+
+    const store = useDashboardStore()
+    await store.fetchAll()
+
+    const card = store.statCards?.find((c) => c.id === 'high-risk-sites')
+    expect(card?.value).toBe('8')
+    expect(card?.trendText).toBe('3 new this month')
+    expect(card?.trendClass).toBe('trend-danger') // newThisMonth > 0
+  })
+
+  it('maps monthlyCases response into statCards[3]', async () => {
+    api.monthlyCases.mockResolvedValue({ year: 2025, month: 4, caseCount: 45, previousMonthCount: 42, delta: 3, direction: 'up' })
+
+    const store = useDashboardStore()
+    await store.fetchAll()
+
+    const card = store.statCards?.find((c) => c.id === 'monthly-cases')
+    expect(card?.value).toBe('45')
+    expect(card?.trendText).toBe('+3 from previous month')
+  })
+
+  /* ── provinces computed mapping ──────────────────────────────── */
+
+  it('maps riskByProvince into provinces computed', async () => {
+    api.riskByProvince.mockResolvedValue({
+      provinces: [
+        { name: 'Gauteng', riskLevel: 'HIGH', riskScore: 88, mdroCount: 42 },
+        { name: 'Western Cape', riskLevel: 'MED', riskScore: 48, mdroCount: 12 },
+      ],
+    })
+
+    const store = useDashboardStore()
+    await store.fetchAll()
+
+    expect(store.provinces).toHaveLength(2)
+    expect(store.provinces![0]).toMatchObject({ name: 'Gauteng', risk: 'HIGH', percent: 88 })
+    expect(store.provinces![1]).toMatchObject({ name: 'Western Cape', risk: 'MED', percent: 48 })
+  })
+
+  /* ── resistanceGenes and affectedRiverSites ───────────────────── */
+
+  it('maps topResistanceGenes into resistanceGenes computed', async () => {
+    api.topResistanceGenes.mockResolvedValue({
+      genes: [{ gene: 'blaCTX-M-14', resistanceClass: 'BETA-LACTAM', subclass: 'CEPHALOSPORIN', isolates: 412, identity: 98.7 }],
+    })
+
+    const store = useDashboardStore()
+    await store.fetchAll()
+
+    expect(store.resistanceGenes).toHaveLength(1)
+    expect(store.resistanceGenes![0].gene).toBe('blaCTX-M-14')
+    expect(store.resistanceGenes![0].isolates).toBe(412)
+  })
+
+  it('maps affectedRiverSites into affectedRiverSites computed', async () => {
+    api.affectedRiverSites.mockResolvedValue({
+      sites: [{ siteId: 'B26', river: 'Apies River', province: 'Gauteng', lastSampled: 'Jan 30, 2026', isolates: 16, risk: 'HIGH' }],
+    })
+
+    const store = useDashboardStore()
+    await store.fetchAll()
+
+    expect(store.affectedRiverSites).toHaveLength(1)
+    expect(store.affectedRiverSites![0].siteId).toBe('B26')
+    expect(store.affectedRiverSites![0].risk).toBe('HIGH')
+  })
+
+  /* ── monthly trend chart data ────────────────────────────────── */
+
+  it('populates months, monthlyNormal, monthlyAlert from monthlyTrendBestYear', async () => {
+    api.monthlyTrendBestYear.mockResolvedValue({
+      year: 2025,
+      data: [
+        { month: 1, monthLabel: 'Jan', caseCount: 10, alert: false },
+        { month: 2, monthLabel: 'Feb', caseCount: 25, alert: true },
+      ],
+    })
+
+    const store = useDashboardStore()
+    await store.fetchAll()
+
+    expect(store.months).toEqual(['Jan', 'Feb'])
+    expect(store.monthlyNormal).toEqual([10, null])  // non-alert → count, alert → null
+    expect(store.monthlyAlert).toEqual([null, 25])   // non-alert → null, alert → count
+    expect(store.trendYear).toBe(2025)
+    expect(store.selectedYear).toBe(2025)
+  })
+
+  it('populates availableYears from availableYears endpoint', async () => {
+    api.availableYears.mockResolvedValue({ years: [2023, 2024, 2025] })
+
+    const store = useDashboardStore()
+    await store.fetchAll()
+
+    expect(store.availableYears).toEqual([2023, 2024, 2025])
+  })
+
+  /* ── selectYear action ───────────────────────────────────────── */
+
+  it('does not call API when selecting the already-selected year', async () => {
+    api.monthlyTrendBestYear.mockResolvedValue({ year: 2025, data: [] })
+
+    const store = useDashboardStore()
+    await store.fetchAll()            // selectedYear → 2025
+
+    vi.clearAllMocks()
+    await store.selectYear(2025)      // same year — should bail out early
+
+    expect(api.monthlyTrend).not.toHaveBeenCalled()
+  })
+
+  it('fetches trend data when a different year is selected', async () => {
+    api.monthlyTrendBestYear.mockResolvedValue({ year: 2025, data: [] })
+    api.monthlyTrend.mockResolvedValue({ year: 2024, data: [] })
+
+    const store = useDashboardStore()
+    await store.fetchAll()
+
+    await store.selectYear(2024)
+
+    expect(api.monthlyTrend).toHaveBeenCalledWith(2024)
+    expect(store.selectedYear).toBe(2024)
+  })
+
+  it('keeps previous trend data if selectYear API call fails', async () => {
+    api.monthlyTrendBestYear.mockResolvedValue({
+      year: 2025,
+      data: [{ month: 1, monthLabel: 'Jan', caseCount: 10, alert: false }],
+    })
+    api.monthlyTrend.mockRejectedValue(new Error('Network error'))
+
+    const store = useDashboardStore()
+    await store.fetchAll()
+
+    const prevMonths = store.months
+    await store.selectYear(2024)
+
+    expect(store.months).toEqual(prevMonths)      // unchanged
+    expect(store.trendLoading).toBe(false)        // loading cleared even on failure
+  })
+})

--- a/frontend/src/stores/__tests__/dashboard.spec.ts
+++ b/frontend/src/stores/__tests__/dashboard.spec.ts
@@ -21,15 +21,17 @@ vi.mock('@/api/dashboard', () => ({
 
 import { dashboardApi } from '@/api/dashboard'
 
-// Typed helpers for mocking
-const api = dashboardApi as Record<string, ReturnType<typeof vi.fn>>
+// vi.mocked gives us properly-typed mock instances
+const api = vi.mocked(dashboardApi)
 
 describe('useDashboardStore', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
     vi.clearAllMocks()
     // Default: all API calls reject (simulates backend unavailable)
-    Object.values(api).forEach((fn) => fn.mockRejectedValue(new Error('Network error')))
+    ;(Object.values(api) as ReturnType<typeof vi.fn>[]).forEach((fn) =>
+      fn.mockRejectedValue(new Error('Network error')),
+    )
   })
 
   /* ── Initial state ───────────────────────────────────────────── */
@@ -194,8 +196,8 @@ describe('useDashboardStore', () => {
     await store.fetchAll()
 
     expect(store.resistanceGenes).toHaveLength(1)
-    expect(store.resistanceGenes![0].gene).toBe('blaCTX-M-14')
-    expect(store.resistanceGenes![0].isolates).toBe(412)
+    expect(store.resistanceGenes![0]!.gene).toBe('blaCTX-M-14')
+    expect(store.resistanceGenes![0]!.isolates).toBe(412)
   })
 
   it('maps affectedRiverSites into affectedRiverSites computed', async () => {
@@ -207,8 +209,8 @@ describe('useDashboardStore', () => {
     await store.fetchAll()
 
     expect(store.affectedRiverSites).toHaveLength(1)
-    expect(store.affectedRiverSites![0].siteId).toBe('B26')
-    expect(store.affectedRiverSites![0].risk).toBe('HIGH')
+    expect(store.affectedRiverSites![0]!.siteId).toBe('B26')
+    expect(store.affectedRiverSites![0]!.risk).toBe('HIGH')
   })
 
   /* ── monthly trend chart data ────────────────────────────────── */

--- a/frontend/src/views/__tests__/BacteriaDetailView.spec.ts
+++ b/frontend/src/views/__tests__/BacteriaDetailView.spec.ts
@@ -55,7 +55,8 @@ describe('BacteriaDetailView', () => {
     // The route param is always shown as the heading (even when unknown),
     // but the organism data (description, gram stain, etc.) falls back to E. coli.
     const wrapper = await mountForOrganism('Unknown%20Organism')
-    const fallbackOrganism = ORGANISM_DB[DEFAULT_ORGANISM]
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const fallbackOrganism = ORGANISM_DB[DEFAULT_ORGANISM]!
     // Description comes from the fallback organism, not the unknown name
     expect(wrapper.find('.organism-desc').text()).toBe(fallbackOrganism.description)
     expect(wrapper.find('.gram-pill').text()).toBe(fallbackOrganism.gramStain)
@@ -63,13 +64,13 @@ describe('BacteriaDetailView', () => {
 
   it('renders the organism description', async () => {
     const wrapper = await mountForOrganism('Escherichia%20coli')
-    const ecoli = ORGANISM_DB['Escherichia coli']
+    const ecoli = ORGANISM_DB['Escherichia coli']!
     expect(wrapper.find('.organism-desc').text()).toBe(ecoli.description)
   })
 
   it('renders the gram stain pill', async () => {
     const wrapper = await mountForOrganism('Escherichia%20coli')
-    expect(wrapper.find('.gram-pill').text()).toBe(ORGANISM_DB['Escherichia coli'].gramStain)
+    expect(wrapper.find('.gram-pill').text()).toBe(ORGANISM_DB['Escherichia coli']!.gramStain)
   })
 
   it('renders the meta pills including common name', async () => {
@@ -87,21 +88,21 @@ describe('BacteriaDetailView', () => {
 
   it('displays total detections in the first KPI card', async () => {
     const wrapper = await mountForOrganism('Escherichia%20coli')
-    const ecoli = ORGANISM_DB['Escherichia coli']
+    const ecoli = ORGANISM_DB['Escherichia coli']!
     const kpiValues = wrapper.findAll('.kpi-value').map((v) => v.text())
     expect(kpiValues[0]).toContain(ecoli.detectionCount.toLocaleString())
   })
 
   it('displays site count in the second KPI card', async () => {
     const wrapper = await mountForOrganism('Escherichia%20coli')
-    const ecoli = ORGANISM_DB['Escherichia coli']
+    const ecoli = ORGANISM_DB['Escherichia coli']!
     const kpiValues = wrapper.findAll('.kpi-value').map((v) => v.text())
     expect(kpiValues[1]).toContain(String(ecoli.siteCount))
   })
 
   it('displays resistance rate in the third KPI card', async () => {
     const wrapper = await mountForOrganism('Escherichia%20coli')
-    const ecoli = ORGANISM_DB['Escherichia coli']
+    const ecoli = ORGANISM_DB['Escherichia coli']!
     const kpiValues = wrapper.findAll('.kpi-value').map((v) => v.text())
     expect(kpiValues[2]).toContain(String(ecoli.resistanceRate))
   })
@@ -110,7 +111,7 @@ describe('BacteriaDetailView', () => {
 
   it('computes R/I/S counts from the resistance profile', async () => {
     const wrapper = await mountForOrganism('Escherichia%20coli')
-    const ecoli = ORGANISM_DB['Escherichia coli']
+    const ecoli = ORGANISM_DB['Escherichia coli']!
 
     const expectedR = ecoli.resistanceProfile.filter((a) => a.level === 'R').length
     const expectedI = ecoli.resistanceProfile.filter((a) => a.level === 'I').length
@@ -149,7 +150,7 @@ describe('BacteriaDetailView', () => {
 
   it('shows the gene count subtitle', async () => {
     const wrapper = await mountForOrganism('Escherichia%20coli')
-    const ecoli = ORGANISM_DB['Escherichia coli']
+    const ecoli = ORGANISM_DB['Escherichia coli']!
     const subtitle = wrapper.find('.panel-subtitle')
     expect(subtitle.text()).toContain(`${ecoli.genes.length} genes detected`)
   })
@@ -159,8 +160,8 @@ describe('BacteriaDetailView', () => {
   it('loads Klebsiella pneumoniae data from the DB', async () => {
     const wrapper = await mountForOrganism('Klebsiella%20pneumoniae')
     expect(wrapper.find('.organism-name').text()).toContain('Klebsiella pneumoniae')
-    const ecoli = ORGANISM_DB['Klebsiella pneumoniae']
-    expect(wrapper.find('.organism-desc').text()).toBe(ecoli.description)
+    const kp = ORGANISM_DB['Klebsiella pneumoniae']!
+    expect(wrapper.find('.organism-desc').text()).toBe(kp.description)
   })
 
   /* ── trendClass helper (via kpi-sub trend class) ─────────────── */

--- a/frontend/src/views/__tests__/BacteriaDetailView.spec.ts
+++ b/frontend/src/views/__tests__/BacteriaDetailView.spec.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, vi } from 'vitest'
+import { shallowMount, flushPromises } from '@vue/test-utils'
+import { createRouter, createMemoryHistory } from 'vue-router'
+
+/* ── Mock the chart theme composable ──────────────────────────── */
+vi.mock('@/composables/useChartTheme', () => ({
+  useChartTheme: () => ({
+    isDark:      { value: false },
+    tooltipBase: { value: {} },
+    axisLabel:   { value: {} },
+    splitLine:   { value: {} },
+    axisLine:    { value: { show: true } },
+    blue:        { value: '#3B82F6' },
+    blueHover:   { value: '#60A5FA' },
+    red:         { value: '#EF4444' },
+    redHover:    { value: '#F87171' },
+    bgBase:      { value: '#FFFFFF' },
+  }),
+}))
+
+import BacteriaDetailView from '@/views/BacteriaDetailView.vue'
+import { ORGANISM_DB, DEFAULT_ORGANISM } from '@/data/organisms'
+
+/* ── Router factory ───────────────────────────────────────────── */
+function makeRouter(name: string) {
+  const r = createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: '/', component: { template: '<div/>' } },
+      { path: '/bacteria/:name', name: 'bacteria-detail', component: BacteriaDetailView },
+    ],
+  })
+  return r
+}
+
+async function mountForOrganism(encodedName: string) {
+  const router = makeRouter(encodedName)
+  await router.push(`/bacteria/${encodedName}`)
+  await router.isReady()
+  return shallowMount(BacteriaDetailView, {
+    global: { plugins: [router] },
+  })
+}
+
+describe('BacteriaDetailView', () => {
+
+  /* ── Organism loading ────────────────────────────────────────── */
+
+  it('renders the organism name from the route param', async () => {
+    const wrapper = await mountForOrganism('Escherichia%20coli')
+    expect(wrapper.find('.organism-name').text()).toContain('Escherichia coli')
+  })
+
+  it('falls back to DEFAULT_ORGANISM (E. coli) data for an unknown organism name', async () => {
+    // The route param is always shown as the heading (even when unknown),
+    // but the organism data (description, gram stain, etc.) falls back to E. coli.
+    const wrapper = await mountForOrganism('Unknown%20Organism')
+    const fallbackOrganism = ORGANISM_DB[DEFAULT_ORGANISM]
+    // Description comes from the fallback organism, not the unknown name
+    expect(wrapper.find('.organism-desc').text()).toBe(fallbackOrganism.description)
+    expect(wrapper.find('.gram-pill').text()).toBe(fallbackOrganism.gramStain)
+  })
+
+  it('renders the organism description', async () => {
+    const wrapper = await mountForOrganism('Escherichia%20coli')
+    const ecoli = ORGANISM_DB['Escherichia coli']
+    expect(wrapper.find('.organism-desc').text()).toBe(ecoli.description)
+  })
+
+  it('renders the gram stain pill', async () => {
+    const wrapper = await mountForOrganism('Escherichia%20coli')
+    expect(wrapper.find('.gram-pill').text()).toBe(ORGANISM_DB['Escherichia coli'].gramStain)
+  })
+
+  it('renders the meta pills including common name', async () => {
+    const wrapper = await mountForOrganism('Escherichia%20coli')
+    const pillText = wrapper.findAll('.meta-pill').map((p) => p.text()).join(' ')
+    expect(pillText).toContain('E. coli')
+  })
+
+  /* ── KPI cards ───────────────────────────────────────────────── */
+
+  it('shows 4 KPI cards', async () => {
+    const wrapper = await mountForOrganism('Escherichia%20coli')
+    expect(wrapper.findAll('.kpi-card')).toHaveLength(4)
+  })
+
+  it('displays total detections in the first KPI card', async () => {
+    const wrapper = await mountForOrganism('Escherichia%20coli')
+    const ecoli = ORGANISM_DB['Escherichia coli']
+    const kpiValues = wrapper.findAll('.kpi-value').map((v) => v.text())
+    expect(kpiValues[0]).toContain(ecoli.detectionCount.toLocaleString())
+  })
+
+  it('displays site count in the second KPI card', async () => {
+    const wrapper = await mountForOrganism('Escherichia%20coli')
+    const ecoli = ORGANISM_DB['Escherichia coli']
+    const kpiValues = wrapper.findAll('.kpi-value').map((v) => v.text())
+    expect(kpiValues[1]).toContain(String(ecoli.siteCount))
+  })
+
+  it('displays resistance rate in the third KPI card', async () => {
+    const wrapper = await mountForOrganism('Escherichia%20coli')
+    const ecoli = ORGANISM_DB['Escherichia coli']
+    const kpiValues = wrapper.findAll('.kpi-value').map((v) => v.text())
+    expect(kpiValues[2]).toContain(String(ecoli.resistanceRate))
+  })
+
+  /* ── R/I/S counts ────────────────────────────────────────────── */
+
+  it('computes R/I/S counts from the resistance profile', async () => {
+    const wrapper = await mountForOrganism('Escherichia%20coli')
+    const ecoli = ORGANISM_DB['Escherichia coli']
+
+    const expectedR = ecoli.resistanceProfile.filter((a) => a.level === 'R').length
+    const expectedI = ecoli.resistanceProfile.filter((a) => a.level === 'I').length
+    const expectedS = ecoli.resistanceProfile.filter((a) => a.level === 'S').length
+
+    expect(wrapper.find('.ris-r').text()).toContain(`R ${expectedR}`)
+    expect(wrapper.find('.ris-i').text()).toContain(`I ${expectedI}`)
+    expect(wrapper.find('.ris-s').text()).toContain(`S ${expectedS}`)
+  })
+
+  /* ── Panel titles ────────────────────────────────────────────── */
+
+  it('renders the AMR genes table panel', async () => {
+    const wrapper = await mountForOrganism('Escherichia%20coli')
+    const titles = wrapper.findAll('.panel-title').map((el) => el.text())
+    expect(titles).toContain('AMR Resistance Genes')
+  })
+
+  it('renders the Antibiotic Resistance Profile panel', async () => {
+    const wrapper = await mountForOrganism('Escherichia%20coli')
+    const titles = wrapper.findAll('.panel-title').map((el) => el.text())
+    expect(titles).toContain('Antibiotic Resistance Profile')
+  })
+
+  it('renders the Affected River Sites panel', async () => {
+    const wrapper = await mountForOrganism('Escherichia%20coli')
+    const titles = wrapper.findAll('.panel-title').map((el) => el.text())
+    expect(titles).toContain('Affected River Sites')
+  })
+
+  it('renders the WGS / Genomic Metrics panel', async () => {
+    const wrapper = await mountForOrganism('Escherichia%20coli')
+    const titles = wrapper.findAll('.panel-title').map((el) => el.text())
+    expect(titles).toContain('WGS / Genomic Metrics')
+  })
+
+  it('shows the gene count subtitle', async () => {
+    const wrapper = await mountForOrganism('Escherichia%20coli')
+    const ecoli = ORGANISM_DB['Escherichia coli']
+    const subtitle = wrapper.find('.panel-subtitle')
+    expect(subtitle.text()).toContain(`${ecoli.genes.length} genes detected`)
+  })
+
+  /* ── Different organisms ─────────────────────────────────────── */
+
+  it('loads Klebsiella pneumoniae data from the DB', async () => {
+    const wrapper = await mountForOrganism('Klebsiella%20pneumoniae')
+    expect(wrapper.find('.organism-name').text()).toContain('Klebsiella pneumoniae')
+    const ecoli = ORGANISM_DB['Klebsiella pneumoniae']
+    expect(wrapper.find('.organism-desc').text()).toBe(ecoli.description)
+  })
+
+  /* ── trendClass helper (via kpi-sub trend class) ─────────────── */
+
+  it('applies trend-danger class when yoyTrend is "up"', async () => {
+    // E. coli has yoyTrend: 'up'
+    const wrapper = await mountForOrganism('Escherichia%20coli')
+    expect(wrapper.find('.kpi-sub').classes()).toContain('trend-danger')
+  })
+
+  /* ── Back button navigation ──────────────────────────────────── */
+
+  it('renders a back button to Dashboard', async () => {
+    const wrapper = await mountForOrganism('Escherichia%20coli')
+    const btn = wrapper.find('.back-btn')
+    expect(btn.exists()).toBe(true)
+    expect(btn.text()).toContain('Dashboard')
+  })
+
+  it('navigates to / when back button is clicked', async () => {
+    const router = makeRouter('Escherichia%20coli')
+    await router.push('/bacteria/Escherichia%20coli')
+    await router.isReady()
+
+    const wrapper = shallowMount(BacteriaDetailView, {
+      global: { plugins: [router] },
+    })
+
+    await wrapper.find('.back-btn').trigger('click')
+    await flushPromises()
+    expect(router.currentRoute.value.path).toBe('/')
+  })
+
+  /* ── Chart panels ────────────────────────────────────────────── */
+
+  it('renders two chart panels (trend and resistance by class)', async () => {
+    const wrapper = await mountForOrganism('Escherichia%20coli')
+    // VChart elements carry class="chart-main" and class="chart-classes" in the template
+    expect(wrapper.find('.chart-main').exists()).toBe(true)
+    expect(wrapper.find('.chart-classes').exists()).toBe(true)
+  })
+})

--- a/frontend/src/views/__tests__/DashboardView.spec.ts
+++ b/frontend/src/views/__tests__/DashboardView.spec.ts
@@ -1,0 +1,251 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { shallowMount } from '@vue/test-utils'
+import { createRouter, createMemoryHistory } from 'vue-router'
+
+/* ── Mock the dashboard store ─────────────────────────────────── */
+const mockFetchAll = vi.fn().mockResolvedValue(undefined)
+const mockSelectYear = vi.fn().mockResolvedValue(undefined)
+
+const mockStore = vi.hoisted(() => ({
+  loading: false,
+  trendLoading: false,
+  error: null as string | null,
+  availableYears: [2024, 2025],
+  selectedYear: 2025,
+  hasIsolateData: false,
+  statCards: null,
+  provinces: null,
+  topOrganisms: null,
+  resistanceGenes: null,
+  affectedRiverSites: null,
+  trendYear: 2025,
+  months: [] as string[],
+  monthlyNormal: [] as (number | null)[],
+  monthlyAlert: [] as (number | null)[],
+  selectYear: vi.fn().mockResolvedValue(undefined),
+  fetchAll: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('@/stores/dashboard', () => ({
+  useDashboardStore: vi.fn(() => mockStore),
+}))
+
+/* ── Mock the chart theme composable ──────────────────────────── */
+vi.mock('@/composables/useChartTheme', () => ({
+  useChartTheme: () => ({
+    isDark:      { value: false },
+    tooltipBase: { value: {} },
+    axisLabel:   { value: {} },
+    splitLine:   { value: {} },
+    axisLine:    { value: { show: true } },
+    blue:        { value: '#3B82F6' },
+    blueHover:   { value: '#60A5FA' },
+    red:         { value: '#EF4444' },
+    redHover:    { value: '#F87171' },
+    bgBase:      { value: '#FFFFFF' },
+  }),
+}))
+
+import DashboardView from '@/views/DashboardView.vue'
+import { STAT_CARDS, PROVINCES, TOP_ORGANISMS } from '@/data/dashboard'
+
+const router = createRouter({
+  history: createMemoryHistory(),
+  routes: [
+    { path: '/', component: DashboardView },
+    { path: '/bacteria/:name', name: 'bacteria-detail', component: { template: '<div/>' } },
+  ],
+})
+
+async function mountDashboard() {
+  await router.push('/')
+  await router.isReady()
+  return shallowMount(DashboardView, {
+    global: { plugins: [router] },
+  })
+}
+
+describe('DashboardView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Reset to default mock state (no live data)
+    mockStore.hasIsolateData = false
+    mockStore.statCards = null
+    mockStore.provinces = null
+    mockStore.topOrganisms = null
+    mockStore.availableYears = [2024, 2025]
+    mockStore.selectedYear = 2025
+    mockStore.error = null
+  })
+
+  /* ── Structural rendering ────────────────────────────────────── */
+
+  it('renders the page title', async () => {
+    const wrapper = await mountDashboard()
+    expect(wrapper.find('.page-title').text()).toBe('Dashboard')
+  })
+
+  it('renders the stats-row section', async () => {
+    const wrapper = await mountDashboard()
+    expect(wrapper.find('.stats-row').exists()).toBe(true)
+  })
+
+  it('calls store.fetchAll on mount', async () => {
+    await mountDashboard()
+    expect(mockStore.fetchAll).toHaveBeenCalledOnce()
+  })
+
+  it('renders 4 StatCard stubs', async () => {
+    const wrapper = await mountDashboard()
+    // shallowMount stubs StatCard as <stat-card-stub>
+    const cards = wrapper.findAll('stat-card-stub')
+    expect(cards).toHaveLength(4)
+  })
+
+  it('renders year toggle buttons for each available year', async () => {
+    const wrapper = await mountDashboard()
+    const buttons = wrapper.findAll('.year-btn')
+    expect(buttons).toHaveLength(2)
+    expect(buttons[0].text()).toBe('2024')
+    expect(buttons[1].text()).toBe('2025')
+  })
+
+  it('marks the selected year button as active', async () => {
+    const wrapper = await mountDashboard()
+    const activeBtn = wrapper.find('.year-btn--active')
+    expect(activeBtn.exists()).toBe(true)
+    expect(activeBtn.text()).toBe('2025')
+  })
+
+  it('disables year buttons when trendLoading is true', async () => {
+    mockStore.trendLoading = true
+    const wrapper = await mountDashboard()
+    const buttons = wrapper.findAll('.year-btn')
+    buttons.forEach((btn) => {
+      expect(btn.attributes('disabled')).toBeDefined()
+    })
+    mockStore.trendLoading = false
+  })
+
+  it('calls store.selectYear when a year button is clicked', async () => {
+    const wrapper = await mountDashboard()
+    const buttons = wrapper.findAll('.year-btn')
+    await buttons[0].trigger('click')
+    expect(mockStore.selectYear).toHaveBeenCalledWith(2024)
+  })
+
+  /* ── Mockdata fallback (hasIsolateData = false) ───────────────── */
+
+  it('renders province rows from mockdata when hasIsolateData is false', async () => {
+    const wrapper = await mountDashboard()
+    const provinceNames = wrapper.findAll('.province-name').map((n) => n.text())
+    expect(provinceNames).toContain('Gauteng')
+    expect(provinceNames).toContain('Western Cape')
+  })
+
+  it('passes STAT_CARDS label to first StatCard stub when hasIsolateData is false', async () => {
+    const wrapper = await mountDashboard()
+    const firstCard = wrapper.findAll('stat-card-stub')[0]
+    expect(firstCard.attributes('label')).toBe(STAT_CARDS[0].label)
+  })
+
+  /* ── Live data override (hasIsolateData = true) ───────────────── */
+
+  it('passes live statCards data to StatCard stubs when hasIsolateData is true', async () => {
+    mockStore.hasIsolateData = true
+    mockStore.statCards = [
+      { id: 'incident-rate', label: 'LIVE Label', value: '99%', trendText: '+1%', trendIcon: null, valueClass: '', trendClass: 'trend-danger' },
+      { id: 'sample-count',  label: 'L2', value: '200', trendText: 'T2', trendIcon: null, valueClass: '', trendClass: 'trend-muted' },
+      { id: 'high-risk-sites', label: 'L3', value: '8', trendText: 'T3', trendIcon: null, valueClass: '', trendClass: 'trend-muted' },
+      { id: 'monthly-cases', label: 'L4', value: '45', trendText: 'T4', trendIcon: null, valueClass: '', trendClass: 'trend-muted' },
+    ]
+
+    const wrapper = await mountDashboard()
+    const firstCard = wrapper.findAll('stat-card-stub')[0]
+    expect(firstCard.attributes('label')).toBe('LIVE Label')
+    expect(firstCard.attributes('value')).toBe('99%')
+  })
+
+  it('uses PROVINCES mockdata for province bars when hasIsolateData is false', async () => {
+    const wrapper = await mountDashboard()
+    const provinceRows = wrapper.findAll('.province-row')
+    expect(provinceRows).toHaveLength(PROVINCES.length)
+  })
+
+  it('shows live province data when hasIsolateData is true and store.provinces is populated', async () => {
+    mockStore.hasIsolateData = true
+    mockStore.provinces = [
+      { name: 'Limpopo', risk: 'LOW', percent: 20 },
+    ]
+
+    const wrapper = await mountDashboard()
+    const names = wrapper.findAll('.province-name').map((n) => n.text())
+    expect(names).toEqual(['Limpopo'])
+  })
+
+  /* ── riskBadgeClass helper (via province badges) ─────────────── */
+
+  it('assigns badge-high class to HIGH risk provinces', async () => {
+    mockStore.hasIsolateData = true
+    mockStore.provinces = [{ name: 'Gauteng', risk: 'HIGH', percent: 88 }]
+
+    const wrapper = await mountDashboard()
+    expect(wrapper.find('.province-badge').classes()).toContain('badge-high')
+  })
+
+  it('assigns badge-med class to MED risk provinces', async () => {
+    mockStore.hasIsolateData = true
+    mockStore.provinces = [{ name: 'Western Cape', risk: 'MED', percent: 48 }]
+
+    const wrapper = await mountDashboard()
+    expect(wrapper.find('.province-badge').classes()).toContain('badge-med')
+  })
+
+  it('assigns badge-low class to LOW risk provinces', async () => {
+    mockStore.hasIsolateData = true
+    mockStore.provinces = [{ name: 'Free State', risk: 'LOW', percent: 15 }]
+
+    const wrapper = await mountDashboard()
+    expect(wrapper.find('.province-badge').classes()).toContain('badge-low')
+  })
+
+  /* ── riskColor helper (via province bar fill inline style) ────── */
+
+  it('sets HIGH risk bar fill to the high-risk CSS variable', async () => {
+    mockStore.hasIsolateData = true
+    mockStore.provinces = [{ name: 'Gauteng', risk: 'HIGH', percent: 88 }]
+
+    const wrapper = await mountDashboard()
+    const fill = wrapper.find('.province-bar-fill')
+    expect(fill.attributes('style')).toContain('var(--c-risk-high)')
+  })
+
+  it('sets LOW risk bar fill to the low-risk CSS variable', async () => {
+    mockStore.hasIsolateData = true
+    mockStore.provinces = [{ name: 'Free State', risk: 'LOW', percent: 15 }]
+
+    const wrapper = await mountDashboard()
+    const fill = wrapper.find('.province-bar-fill')
+    expect(fill.attributes('style')).toContain('var(--c-risk-low)')
+  })
+
+  /* ── Navigation ──────────────────────────────────────────────── */
+
+  it('renders the organisms panel section', async () => {
+    const wrapper = await mountDashboard()
+    const titles = wrapper.findAll('.panel-title').map((el) => el.text())
+    expect(titles).toContain('Top Detected Organisms')
+  })
+
+  it('renders the resistance genes panel section', async () => {
+    const wrapper = await mountDashboard()
+    const titles = wrapper.findAll('.panel-title').map((el) => el.text())
+    expect(titles).toContain('Top Resistance Genes')
+  })
+
+  it('renders the river sites panel section', async () => {
+    const wrapper = await mountDashboard()
+    const titles = wrapper.findAll('.panel-title').map((el) => el.text())
+    expect(titles).toContain('Affected River Sites')
+  })
+})

--- a/frontend/src/views/__tests__/DashboardView.spec.ts
+++ b/frontend/src/views/__tests__/DashboardView.spec.ts
@@ -3,21 +3,23 @@ import { shallowMount } from '@vue/test-utils'
 import { createRouter, createMemoryHistory } from 'vue-router'
 
 /* ── Mock the dashboard store ─────────────────────────────────── */
-const mockFetchAll = vi.fn().mockResolvedValue(undefined)
-const mockSelectYear = vi.fn().mockResolvedValue(undefined)
-
 const mockStore = vi.hoisted(() => ({
   loading: false,
   trendLoading: false,
   error: null as string | null,
-  availableYears: [2024, 2025],
+  availableYears: [2024, 2025] as number[],
   selectedYear: 2025,
   hasIsolateData: false,
-  statCards: null,
-  provinces: null,
-  topOrganisms: null,
-  resistanceGenes: null,
-  affectedRiverSites: null,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  statCards: null as any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  provinces: null as any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  topOrganisms: null as any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  resistanceGenes: null as any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  affectedRiverSites: null as any,
   trendYear: 2025,
   months: [] as string[],
   monthlyNormal: [] as (number | null)[],
@@ -106,8 +108,8 @@ describe('DashboardView', () => {
     const wrapper = await mountDashboard()
     const buttons = wrapper.findAll('.year-btn')
     expect(buttons).toHaveLength(2)
-    expect(buttons[0].text()).toBe('2024')
-    expect(buttons[1].text()).toBe('2025')
+    expect(buttons[0]!.text()).toBe('2024')
+    expect(buttons[1]!.text()).toBe('2025')
   })
 
   it('marks the selected year button as active', async () => {
@@ -130,7 +132,7 @@ describe('DashboardView', () => {
   it('calls store.selectYear when a year button is clicked', async () => {
     const wrapper = await mountDashboard()
     const buttons = wrapper.findAll('.year-btn')
-    await buttons[0].trigger('click')
+    await buttons[0]!.trigger('click')
     expect(mockStore.selectYear).toHaveBeenCalledWith(2024)
   })
 
@@ -145,8 +147,8 @@ describe('DashboardView', () => {
 
   it('passes STAT_CARDS label to first StatCard stub when hasIsolateData is false', async () => {
     const wrapper = await mountDashboard()
-    const firstCard = wrapper.findAll('stat-card-stub')[0]
-    expect(firstCard.attributes('label')).toBe(STAT_CARDS[0].label)
+    const firstCard = wrapper.findAll('stat-card-stub')[0]!
+    expect(firstCard.attributes('label')).toBe(STAT_CARDS[0]!.label)
   })
 
   /* ── Live data override (hasIsolateData = true) ───────────────── */
@@ -161,7 +163,7 @@ describe('DashboardView', () => {
     ]
 
     const wrapper = await mountDashboard()
-    const firstCard = wrapper.findAll('stat-card-stub')[0]
+    const firstCard = wrapper.findAll('stat-card-stub')[0]!
     expect(firstCard.attributes('label')).toBe('LIVE Label')
     expect(firstCard.attributes('value')).toBe('99%')
   })


### PR DESCRIPTION
- Implement E2E tests for the Dashboard page using Playwright, covering page structure, stat cards, charts, and navigation.
- Create unit tests for StatCard component to validate rendering and props behavior.
- Add unit tests for dashboard store to mock API responses and verify state management.
- Develop unit tests for BacteriaDetailView to ensure correct rendering based on route parameters and fallback data.
- Introduce unit tests for DashboardView to validate structural rendering, data fetching, and conditional rendering based on store state.